### PR TITLE
Fix FolderMonitor BSTR allocation and handle failures

### DIFF
--- a/BG3ModStudio/FolderMonitor.cpp
+++ b/BG3ModStudio/FolderMonitor.cpp
@@ -103,9 +103,13 @@ void FolderMonitor::Monitor()
             CStringW path;
             path.Format(L"%s\\%s", m_directory.GetString(), fileName.GetString());
 
-            auto bstrFilename = SysAllocStringLen(path.GetString(), path.GetLength() * sizeof(WCHAR));
+            auto bstrFilename = SysAllocStringLen(path.GetString(), path.GetLength());
 
-            PostMessage(m_hWndTarget, WM_FILE_CHANGED, pFni->Action, reinterpret_cast<LPARAM>(bstrFilename));
+            if (bstrFilename == nullptr) {
+                ATLTRACE("Failed to allocate BSTR for file change path: %S\n", path.GetString());
+            } else {
+                PostMessage(m_hWndTarget, WM_FILE_CHANGED, pFni->Action, reinterpret_cast<LPARAM>(bstrFilename));
+            }
 
             if (pFni->NextEntryOffset == 0) {
                 break;


### PR DESCRIPTION
## Summary
- allocate BSTRs for file change messages using the correct UTF-16 length
- log a failure and skip posting a message when BSTR allocation fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1717c5d083239b02be135c804def